### PR TITLE
feat: add GPX export functionality

### DIFF
--- a/X2D GPS Companion/Backend/GPXExporter.swift
+++ b/X2D GPS Companion/Backend/GPXExporter.swift
@@ -1,0 +1,78 @@
+//
+//  GPXExporter.swift
+//  X2D GPS Companion
+//
+//  Created by Codex on 12/01/2026.
+//
+
+import Foundation
+
+struct GPXExporter {
+    static func export(records: [LocationRecord], fileName: String) throws -> URL {
+        let gpx = makeGPX(records: records, creator: "X2D GPS Companion")
+
+        var url = FileManager.default.temporaryDirectory
+        url.appendPathComponent(fileName)
+        url.appendPathExtension("gpx")
+
+        try gpx.write(to: url, atomically: true, encoding: .utf8)
+        return url
+    }
+
+    static func defaultFileName(from startDate: Date, to endDate: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyyMMdd"
+
+        return "X2D-GPS-Track-\(formatter.string(from: startDate))-\(formatter.string(from: endDate))"
+    }
+
+    static func makeGPX(records: [LocationRecord], creator: String) -> String {
+        var lines: [String] = []
+        lines.reserveCapacity(max(64, records.count * 10))
+
+        let iso8601 = ISO8601DateFormatter()
+        iso8601.timeZone = TimeZone(secondsFromGMT: 0)
+        iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        lines.append(#"<?xml version="1.0" encoding="UTF-8"?>"#)
+        lines.append(
+            #"<gpx version="1.1" creator="\#(xmlEscape(creator))" xmlns="http://www.topografix.com/GPX/1/1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">"#
+        )
+        lines.append("  <trk>")
+        lines.append("    <name>\(xmlEscape("Location Track"))</name>")
+        lines.append("    <trkseg>")
+
+        for record in records {
+            let time = iso8601.string(from: record.timestamp)
+            lines.append(String(format: "      <trkpt lat=\"%.8f\" lon=\"%.8f\">", record.latitude, record.longitude))
+            lines.append(String(format: "        <ele>%.3f</ele>", record.altitude))
+            lines.append("        <time>\(time)</time>")
+            lines.append("        <extensions>")
+            lines.append(String(format: "          <horizontalAccuracy>%.3f</horizontalAccuracy>", record.horizontalAccuracy))
+            lines.append(String(format: "          <verticalAccuracy>%.3f</verticalAccuracy>", record.verticalAccuracy))
+            lines.append(String(format: "          <speed>%.3f</speed>", record.speed))
+            lines.append(String(format: "          <course>%.3f</course>", record.course))
+            lines.append("        </extensions>")
+            lines.append("      </trkpt>")
+        }
+
+        lines.append("    </trkseg>")
+        lines.append("  </trk>")
+        lines.append("</gpx>")
+
+        return lines.joined(separator: "\n")
+    }
+
+    private static func xmlEscape(_ text: String) -> String {
+        var escaped = text
+        escaped = escaped.replacingOccurrences(of: "&", with: "&amp;")
+        escaped = escaped.replacingOccurrences(of: "<", with: "&lt;")
+        escaped = escaped.replacingOccurrences(of: ">", with: "&gt;")
+        escaped = escaped.replacingOccurrences(of: "\"", with: "&quot;")
+        escaped = escaped.replacingOccurrences(of: "'", with: "&apos;")
+        return escaped
+    }
+}

--- a/X2D GPS Companion/Backend/ViewModel+Export.swift
+++ b/X2D GPS Companion/Backend/ViewModel+Export.swift
@@ -1,0 +1,40 @@
+//
+//  ViewModel+Export.swift
+//  X2D GPS Companion
+//
+//  Created by Codex on 12/01/2026.
+//
+
+import Foundation
+
+enum GPXExportError: LocalizedError {
+    case invalidDateRange
+    case noRecords
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidDateRange:
+            String(localized: "EXPORT_GPX_INVALID_RANGE")
+        case .noRecords:
+            String(localized: "EXPORT_GPX_NO_RECORDS")
+        }
+    }
+}
+
+extension ViewModel {
+    func exportGPX(from startDate: Date, to endDate: Date) throws -> URL {
+        guard endDate > startDate else {
+            throw GPXExportError.invalidDateRange
+        }
+
+        let interval = DateInterval(start: startDate, end: endDate)
+        let records = try locationDatabase.records(in: interval)
+        guard !records.isEmpty else {
+            throw GPXExportError.noRecords
+        }
+
+        let inclusiveEndDate = endDate.addingTimeInterval(-1)
+        let fileName = GPXExporter.defaultFileName(from: startDate, to: inclusiveEndDate)
+        return try GPXExporter.export(records: records, fileName: fileName)
+    }
+}

--- a/X2D GPS Companion/Interface/ExportGPXView.swift
+++ b/X2D GPS Companion/Interface/ExportGPXView.swift
@@ -1,0 +1,153 @@
+//
+//  ExportGPXView.swift
+//  X2D GPS Companion
+//
+//  Created by Codex on 12/01/2026.
+//
+
+import SwiftUI
+import UIKit
+
+struct ExportGPXView<Content: View>: View {
+    @Bindable var model: ViewModel
+
+    @State private var isPresented: Bool = false
+    @State private var fromDate: Date = Calendar.current.startOfDay(for: Date())
+    @State private var toDate: Date = Calendar.current.startOfDay(for: Date())
+    @State private var isExporting: Bool = false
+    @State private var presentError: String = ""
+    @State private var shareItem: ShareItem?
+
+    let content: () -> Content
+
+    init(model: ViewModel, @ViewBuilder content: @escaping () -> Content) {
+        self.model = model
+        self.content = content
+    }
+
+    var body: some View {
+        Button {
+            isPresented = true
+        } label: {
+            content()
+        }
+        .disabled(isExporting)
+        .sheet(isPresented: $isPresented) {
+            ExportGPXSheet(
+                model: model,
+                fromDate: $fromDate,
+                toDate: $toDate,
+                isExporting: $isExporting,
+                presentError: $presentError,
+                shareItem: $shareItem
+            )
+        }
+    }
+}
+
+private struct ExportGPXSheet: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @Bindable var model: ViewModel
+    @Binding var fromDate: Date
+    @Binding var toDate: Date
+    @Binding var isExporting: Bool
+    @Binding var presentError: String
+    @Binding var shareItem: ShareItem?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("EXPORT_GPX_DATE_RANGE") {
+                    DatePicker(
+                        "EXPORT_GPX_FROM",
+                        selection: $fromDate,
+                        displayedComponents: [.date]
+                    )
+                    DatePicker(
+                        "EXPORT_GPX_TO",
+                        selection: $toDate,
+                        in: fromDate...,
+                        displayedComponents: [.date]
+                    )
+                }
+
+                Section {
+                    Button { export() } label: {
+                        if isExporting {
+                            ProgressView()
+                        } else {
+                            AlignedLabel(icon: "square.and.arrow.up", text: "EXPORT_GPX")
+                        }
+                    }
+                    .disabled(isExporting)
+                }
+            }
+            .navigationTitle("EXPORT_GPX")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("CANCEL") { dismiss() }
+                }
+            }
+        }
+        .alert(
+            "ERROR",
+            isPresented: .init(
+                get: { !presentError.isEmpty },
+                set: { newValue in if !newValue { presentError = "" } }
+            )
+        ) {
+            Button("OK", role: .cancel) { presentError = "" }
+        } message: {
+            Text(presentError)
+        }
+        .sheet(item: $shareItem) { item in
+            ActivityView(activityItems: [item.url])
+        }
+    }
+
+    private func export() {
+        isExporting = true
+        presentError = ""
+        shareItem = nil
+
+        Task { @MainActor in
+            defer { isExporting = false }
+            do {
+                let (start, end) = normalizeDateRange(from: fromDate, to: toDate)
+                let url = try model.exportGPX(from: start, to: end)
+                shareItem = ShareItem(url: url)
+            } catch {
+                print("❌ Failed to export GPX: \(error.localizedDescription)")
+                presentError = error.localizedDescription
+            }
+        }
+    }
+
+    private func normalizeDateRange(from start: Date, to end: Date) -> (start: Date, end: Date) {
+        let calendar = Calendar.current
+        let start = calendar.startOfDay(for: start)
+        let endStart = calendar.startOfDay(for: end)
+        let end = calendar.date(byAdding: .day, value: 1, to: endStart) ?? endStart
+        return (start: start, end: end)
+    }
+}
+
+private struct ShareItem: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+
+private struct ActivityView: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    let applicationActivities: [UIActivity]? = nil
+
+    func makeUIViewController(context _: Context) -> UIActivityViewController {
+        UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: applicationActivities
+        )
+    }
+
+    func updateUIViewController(_: UIActivityViewController, context _: Context) {}
+}

--- a/X2D GPS Companion/Interface/SettingsView.swift
+++ b/X2D GPS Companion/Interface/SettingsView.swift
@@ -33,6 +33,11 @@ struct SettingsView: View {
                 }
                 .disabled(isInProgress)
 
+                ExportGPXView(model: model) {
+                    AlignedLabel(icon: "square.and.arrow.up.on.square.fill", text: "EXPORT_GPX")
+                }
+                .disabled(isInProgress)
+
                 Toggle("OVERWRITE_EXISTING_LOCATION", isOn: $model.overwriteExistingLocation)
 
                 VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
The tool allows users to easily embed GPS coordinates into photos using ExifTool, without requiring Hasselblad.

Hope you think this is useful.

Note:
Since I currently don't have a camera, I can't test whether this GPX file is usable.
And these codes were written by me using the Codex `5.2-xhigh` model. If you mind, just close this PR.